### PR TITLE
Pkg 1672/v1.4.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+# upload_channels:
+#   - sfe1ed40
+
+# channels:
+#   - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,30 +21,12 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.7
-    - fastcore
-    - gdown
-    - hyperopt
-    - matplotlib-base
-    - numba
-    - openpyxl
-    - pandas
-    - pip
-    - py7zr >=0.18.1
-    - pytorch-lightning >=1.3.0
-    - requests
-    - scikit-learn
-    - statsmodels
-    - pytorch >=1.4
-    - torchinfo
-    - tqdm
-    - xlrd
-    # The following is necessary to pass pip-check
-    # pyDeprecate==0.3.1 is necessary for PL==1.5.10
-    - pyDeprecate 0.3.1
-    # pyppmd and zipfile-deflate constraints are necessary for py7zr
-    - pyppmd >=0.17.0,<0.18.0
-    - zipfile-deflate64 >=0.2.0
+    - python
+    - numpy
+    - pandas >=1.3.5
+    - pytorch >=2.0.0
+    - pytorch-lightning >=2.0.0
+    - ray-tune >=2.2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/neuralforecast-{{ version }}.tar.gz
   sha256: c1084144a1c8009ac92ef5d1b9f9c2efa7c130685b080212dee0516153692dbf
+  patches:
+    - patches/001_relax_reqs.patch
 
 build:
   number: 0
@@ -16,6 +18,9 @@ build:
   skip: true  # [py<36 or (not win) or (not linux-64)]
 
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,9 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  # ray-tune is only available on win64 and linux-64
-  skip: true  # [py<36 or (not win) or (not linux64)]
+  # ray-tune is only available on win64 and linux-64 for py<311
+  skip: true  # [py<36 or py>310]
+  skip: true  # [((not linux64) and (not win64))]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,9 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  # ray-tune is only available on win64 and linux-64 for py<311
+  # ray-tune is only available for py<311 and is missing on s390x, ppc64le and aarch64
   skip: true  # [py<36 or py>310]
-  skip: true  # [((not linux64) and (not win64))]
+  skip: true  # [(linux and (s390x or ppc64le or aarch64))]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,11 +49,10 @@ requirements:
 test:
   imports:
     - neuralforecast
-  ## Skipping pip-check (as build keeps failing)
-  # commands:
-  #   - pip check
-  # requires:
-  #   - pip
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/Nixtla/neuralforecast/tree/main/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,8 @@ test:
 about:
   home: https://github.com/Nixtla/neuralforecast/tree/main/
   summary: Deep Learning for Time Series Forecasting
-  license: GPL-3.0-only
+  license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   description: |
     State-of-the-art time series forecasting for PyTorch.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   # ray-tune is only available on win64 and linux-64
-  skip: true  # [py<36 or (not win) or (not linux-64)]
+  skip: true  # [py<36 or (not win) or (not linux64)]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,16 @@ source:
   sha256: c1084144a1c8009ac92ef5d1b9f9c2efa7c130685b080212dee0516153692dbf
 
 build:
-  number: 1
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<36]
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
     - python >=3.7
     - fastcore

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,9 @@ requirements:
     - python
     - numpy
     - pandas >=1.3.5
-    - pytorch >=2.0.0
-    - pytorch-lightning >=2.0.0
-    - ray-tune >=2.2.0
+    - pytorch >=1.12.1
+    - pytorch-lightning 1.9.3
+    # - ray-tune 2.3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<36]
+  # ray-tune is only available on win64 and linux-64
+  skip: true  # [py<36 or (not win) or (not linux-64)]
 
 requirements:
   host:
@@ -26,7 +27,7 @@ requirements:
     - pandas >=1.3.5
     - pytorch >=1.12.1
     - pytorch-lightning 1.9.3
-    # - ray-tune 2.3.0
+    - ray-tune 2.3.0
 
 test:
   imports:

--- a/recipe/patches/001_relax_reqs.patch
+++ b/recipe/patches/001_relax_reqs.patch
@@ -1,0 +1,13 @@
+diff --git a/settings.ini b/settings.ini
+index d5e5157..66e4e06 100644
+--- a/settings.ini
++++ b/settings.ini
+@@ -15,7 +15,7 @@ language = English
+ custom_sidebar = True
+ license = apache2
+ status = 2
+-requirements = numpy>=1.21.6 pandas>=1.3.5 torch>=1.12.1 pytorch-lightning==1.6.5 ray[tune]==2.0.1
++requirements = numpy>=1.21.6 pandas>=1.3.5 torch>=1.12.1 pytorch-lightning==1.9.3 ray[tune]==2.3.0
+ dev_requirements = nbdev black mypy flake8 matplotlib
+ nbs_path = nbs
+ doc_path = _docs


### PR DESCRIPTION
# neuralforecast v1.4.0
upstream: https://github.com/Nixtla/neuralforecast/tree/v1.4.0

## Changes
- Fork from CF
- Correct the dependencies to match upstream
- Add patch to relax version requirement for ray-tune and pytorch-lightning


## Notes
- v1.5.0 is available but needs PyTorch 2.0
- This is destined for SnowFlake, channel will be added after approval.
- After investigation we have determined there is no harm in using newer (available) versions of ray-tune and pytorch-lightning
- `ray-tune` is not available on 390x, aarch64 or ppc64le